### PR TITLE
Fix compile issues

### DIFF
--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -258,12 +258,10 @@ ERF::initHSE()
     erf_enforce_hse(h_dens_hse[level],h_pres_hse[level]);
 
     // Copy from host version to device version
-#if 0
     amrex::Gpu::copy(amrex::Gpu::hostToDevice, h_dens_hse[level].begin(), h_dens_hse[level].end(),
-                     d_dens_hse[level]);
+                     d_dens_hse[level].begin());
     amrex::Gpu::copy(amrex::Gpu::hostToDevice, h_pres_hse[level].begin(), h_pres_hse[level].end(),
-                     d_dens_hse[level]);
-#endif
+                     d_dens_hse[level].begin());
 }
 
 void

--- a/Source/TimeIntegration/TimeIntegration_rhs.cpp
+++ b/Source/TimeIntegration/TimeIntegration_rhs.cpp
@@ -16,7 +16,7 @@ void erf_rhs (int level,
               const amrex::Geometry geom, const amrex::Real* dxp, const amrex::Real dt,
                     amrex::InterpFaceRegister* ifr,
               const SolverChoice& solverChoice,
-              amrex::Real* dptr_dens_hse, amrex::Real* dptr_pres_hse)
+              const amrex::Real* dptr_dens_hse, const amrex::Real* dptr_pres_hse)
 {
     BL_PROFILE_VAR("erf_rhs()",erf_rhs);
 


### PR DESCRIPTION
This fixes two compile issues:

1. `erf_rhs` takes `const amrex::Real*` for the hse vector data
2. `Gpu::copy()` requires the destination memory address from `amrex::Vector::begin()` as the last argument

The ABL case compiles and takes timesteps with the GPU copy uncommented in Setup.cpp now :)